### PR TITLE
updates to README, variables file

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ This repository contains the files necessary to set up an Amazon EC2 Container S
   * An Amazon Access Key ID and Secret Access Key with rights to install infrastructure
   * Amazon ECS cluster name that you'll register this infrastructure with (created above)
   * An Amazon Key Pair name (usable in the us-east-1 region if you will use Amazon ECR)
+* The scripts will default to creating the infrastructure in the us-east-1 region
+  * If you'd like to change the region, either specify the value as an additional option
+  on the command line (e.g. '-var region=eu-west-1') or change the default value in the
+  default/variables.tf file
+  * Note: you will have to have a key pair created in the region you specify for use in the command lines below.
 * Execute the following command to see what will be set up on AWS:
 ```
 $ terraform plan -var aws_access_key_id=yourKeyId -var aws_secret_access_key=yourSecretKey -var aws_key_name=yourKeyPairName -var cluster_name=yourClusterName

--- a/default/variables.tf
+++ b/default/variables.tf
@@ -13,7 +13,7 @@ variable "region" {
 }
 
 variable "availability_zone" {
-  description = "availability zone used for the demo"
+  description = "availability zone used for the demo, based on region"
   default = {
     us-east-1 = "us-east-1a"
     us-west-1 = "us-west-1a"


### PR DESCRIPTION
Instructions added to allow for regions other than us-east-1 to be specified.  Note the allowed regions only include those with AMIs optimized for ECS.  These currently include:
    us-east-1 = "ami-cb2305a1"
    us-west-1 = "ami-bdafdbdd"
    us-west-2 = "ami-ec75908c"
    eu-west-1 = "ami-13f84d60"
    eu-central-1 = "ami-c3253caf"
    ap-northeast-1 = "ami-e9724c87"
    ap-southeast-1 = "ami-5f31fd3c"
    ap-southeast-2 = "ami-83af8ae0"